### PR TITLE
Keep original filename after decryption

### DIFF
--- a/bin/decrypt.sh
+++ b/bin/decrypt.sh
@@ -21,12 +21,16 @@ if [ ! -f "${2}" ]; then
 	exit 1
 fi
 
+case "${2}" in
+        *.enc) OUT_FILENAME="$(basename "${2}" .enc)";;
+        *)     OUT_FILENAME="${2}.decrypted"
+esac
 
 openssl smime -decrypt \
 	-in "${2}" \
 	-binary -inform DEM \
 	-inkey "${1}" \
-	-out "${2}.decrypted"
+        -out "${OUT_FILENAME}"
 
 if [ $? -ne 0 ]; then
 	exit 1


### PR DESCRIPTION
Mysqldump-secure suffixes encrypted files with ".enc" extension. Decrypt.sh adds a ".decrypted" extension. When gzip -d, gzip then complains about an unknown suffix.
With this change encrypted Mysqldump-secure dumps will get their original filename after decryption and can be decompressed without renaming them again.