### PR TITLE
Fix error when running with MySQL 8.0.4+

### DIFF
--- a/bin/mysqldump-secure
+++ b/bin/mysqldump-secure
@@ -1927,7 +1927,7 @@ mysql_database_is_empty() {
 	# If a database does not show up in information_schema.tables, it means it
 	# has no tables yet and is therefore empty.
 	# If count == 0, return '0', else '1'
-	_query="SELECT IF(COUNT(*) = 0, '0', '1') AS empty
+	_query="SELECT IF(COUNT(*) = 0, '0', '1') AS is_empty
 				FROM INFORMATION_SCHEMA.TABLES
 				WHERE TABLE_SCHEMA = '${_database}';"
 


### PR DESCRIPTION
Resolves #32 

Since MySQL 8.0.4 `empty` is a reserved word.

https://dev.mysql.com/doc/refman/8.0/en/keywords.html